### PR TITLE
Stop sorting config keys for newer ruby versions.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@ class sssd::config (
   $ensure                  = $sssd::ensure,
   $config                  = $sssd::config,
   $config_file             = $sssd::config_file,
+  $config_template         = $sssd::config_template,
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
@@ -14,7 +15,7 @@ class sssd::config (
     owner   => 'root',
     group   => 'root',
     mode    => '0600',
-    content => template("${module_name}/sssd.conf.erb"),
+    content => template($config_template),
   }
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class sssd (
   $extra_packages          = $sssd::params::extra_packages,
   $extra_packages_ensure   = $sssd::params::extra_packages_ensure,
   $config_file             = $sssd::params::config_file,
+  $config_template         = $sssd::params::config_template,
   $mkhomedir               = $sssd::params::mkhomedir,
   $manage_oddjobd          = $sssd::params::manage_oddjobd,
   $service_ensure          = $sssd::params::service_ensure,
@@ -85,7 +86,8 @@ class sssd (
 
   validate_string(
     $sssd_package,
-    $sssd_service
+    $sssd_service,
+    $config_template
   )
 
   validate_array(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,14 @@ class sssd::params {
   $enable_mkhomedir_flags  = ['--enablesssd', '--enablesssdauth', '--enablemkhomedir']
   $disable_mkhomedir_flags = ['--enablesssd', '--enablesssdauth', '--disablemkhomedir']
 
+  # Earlier versions of ruby didn't provide ordered hashs, so we need to sort
+  # the configuration ourselves to ensure a consistent config file.
+  if versioncmp($::rubyversion, '1.9.3') >= 0 {
+    $config_template = "${module_name}/sssd.conf.erb"
+  } else {
+    $config_template = "${module_name}/sssd.conf.sorted.erb"
+  }
+
   case $::osfamily {
 
     'RedHat': {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,22 +1,25 @@
 require 'spec_helper'
 describe 'sssd' do
   describe 'on RedHat 5.11' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystemrelease => '5.7',
-      :rubyversion => '1.9.3'
-    } }
+    let(:facts) do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '5.7',
+        :rubyversion => '1.9.3'
+      }
+    end
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
 
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
-      }
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
 
       it { is_expected.to contain_package('authconfig').with_ensure('latest') }
       it { is_expected.not_to contain_package('oddjob-mkhomedir') }
@@ -32,35 +35,41 @@ describe 'sssd' do
     end
 
     context 'with ruby without ordered hashes' do
-      let(:facts) { {
-        :osfamily => 'RedHat',
-        :operatingsystemrelease => '5.7',
-        :rubyversion => '1.8.7'
-      } }
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
-      }
+      let(:facts) do
+        {
+          :osfamily => 'RedHat',
+          :operatingsystemrelease => '5.7',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      end
     end
   end
   describe 'on RedHat 6.6' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystemrelease => '6.6',
-      :rubyversion => '1.9.3'
-    } }
+    let(:facts) do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '6.6',
+        :rubyversion => '1.9.3'
+      }
+    end
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
 
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
-      }
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
 
       it { is_expected.to contain_package('authconfig').with_ensure('present') }
       it { is_expected.to contain_package('oddjob-mkhomedir') }
@@ -78,35 +87,41 @@ describe 'sssd' do
     end
 
     context 'with ruby without ordered hashes' do
-      let(:facts) { {
-        :osfamily => 'RedHat',
-        :operatingsystemrelease => '6.6',
-        :rubyversion => '1.8.7'
-      } }
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
-      }
+      let(:facts) do
+        {
+          :osfamily => 'RedHat',
+          :operatingsystemrelease => '6.6',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      end
     end
   end
   describe 'on RedHat 7.1' do
-    let(:facts) { {
-      :osfamily => 'RedHat',
-      :operatingsystemrelease => '7.1',
-      :rubyversion => '1.9.3'
-    } }
+    let(:facts) do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '7.1',
+        :rubyversion => '1.9.3'
+      }
+    end
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
 
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
-      }
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
 
       it { is_expected.to contain_package('authconfig').with_ensure('present') }
       it { is_expected.to contain_package('oddjob-mkhomedir') }
@@ -124,35 +139,41 @@ describe 'sssd' do
     end
 
     context 'with ruby without ordered hashes' do
-      let(:facts) { {
-        :osfamily => 'RedHat',
-        :operatingsystemrelease => '7.1',
-        :rubyversion => '1.8.7'
-      } }
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
-      }
+      let(:facts) do
+        {
+          :osfamily => 'RedHat',
+          :operatingsystemrelease => '7.1',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      end
     end
   end
   describe 'on Debian 8.1' do
-    let(:facts) { {
-      :osfamily => 'Debian',
-      :operatingsystemrelease => '8.1',
-      :rubyversion => '1.9.3'
-    } }
+    let(:facts) do
+      {
+        :osfamily => 'Debian',
+        :operatingsystemrelease => '8.1',
+        :rubyversion => '1.9.3'
+      }
+    end
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
 
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
-      }
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
 
       it { is_expected.not_to contain_package('authconfig') }
       it { is_expected.not_to contain_package('oddjob-mkhomedir') }
@@ -168,16 +189,19 @@ describe 'sssd' do
     end
 
     context 'with ruby without ordered hashes' do
-      let(:facts) { {
-        :osfamily => 'Debian',
-        :operatingsystemrelease => '8.1',
-        :rubyversion => '1.8.7'
-      } }
-      it { is_expected.to contain_file('sssd.conf') \
-        .with_ensure('present') \
-        .with_path('/etc/sssd/sssd.conf') \
-        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
-      }
+      let(:facts) do
+        {
+          :osfamily => 'Debian',
+          :operatingsystemrelease => '8.1',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,12 +1,22 @@
 require 'spec_helper'
 describe 'sssd' do
   describe 'on RedHat 5.11' do
-    let(:facts) { { :osfamily => 'RedHat', :operatingsystemrelease => '5.7' } }
+    let(:facts) { {
+      :osfamily => 'RedHat',
+      :operatingsystemrelease => '5.7',
+      :rubyversion => '1.9.3'
+    } }
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
+
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      }
 
       it { is_expected.to contain_package('authconfig').with_ensure('latest') }
       it { is_expected.not_to contain_package('oddjob-mkhomedir') }
@@ -20,14 +30,37 @@ describe 'sssd' do
       let(:params) { { :service_ensure => 'stopped' } }
       it { is_expected.to contain_service('sssd').with_ensure('stopped') }
     end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '5.7',
+        :rubyversion => '1.8.7'
+      } }
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      }
+    end
   end
   describe 'on RedHat 6.6' do
-    let(:facts) { { :osfamily => 'RedHat', :operatingsystemrelease => '6.6' } }
+    let(:facts) { {
+      :osfamily => 'RedHat',
+      :operatingsystemrelease => '6.6',
+      :rubyversion => '1.9.3'
+    } }
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
+
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      }
 
       it { is_expected.to contain_package('authconfig').with_ensure('present') }
       it { is_expected.to contain_package('oddjob-mkhomedir') }
@@ -42,15 +75,38 @@ describe 'sssd' do
       let(:params) { { :service_ensure => 'stopped' } }
       it { is_expected.to contain_service('sssd').with_ensure('stopped') }
       it { is_expected.to contain_service('oddjobd').with_ensure('stopped') }
+    end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '6.6',
+        :rubyversion => '1.8.7'
+      } }
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      }
     end
   end
   describe 'on RedHat 7.1' do
-    let(:facts) { { :osfamily => 'RedHat', :operatingsystemrelease => '7.1' } }
+    let(:facts) { {
+      :osfamily => 'RedHat',
+      :operatingsystemrelease => '7.1',
+      :rubyversion => '1.9.3'
+    } }
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
+
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      }
 
       it { is_expected.to contain_package('authconfig').with_ensure('present') }
       it { is_expected.to contain_package('oddjob-mkhomedir') }
@@ -66,14 +122,37 @@ describe 'sssd' do
       it { is_expected.to contain_service('sssd').with_ensure('stopped') }
       it { is_expected.to contain_service('oddjobd').with_ensure('stopped') }
     end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '7.1',
+        :rubyversion => '1.8.7'
+      } }
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      }
+    end
   end
   describe 'on Debian 8.1' do
-    let(:facts) { { :osfamily => 'Debian', :operatingsystemrelease => '8.1' } }
+    let(:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystemrelease => '8.1',
+      :rubyversion => '1.9.3'
+    } }
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('sssd::install') }
       it { is_expected.to contain_class('sssd::config') }
       it { is_expected.to contain_class('sssd::service') }
+
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      }
 
       it { is_expected.not_to contain_package('authconfig') }
       it { is_expected.not_to contain_package('oddjob-mkhomedir') }
@@ -86,6 +165,19 @@ describe 'sssd' do
     context 'with service ensure stopped' do
       let(:params) { { :service_ensure => 'stopped' } }
       it { is_expected.to contain_service('sssd').with_ensure('stopped') }
+    end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) { {
+        :osfamily => 'Debian',
+        :operatingsystemrelease => '8.1',
+        :rubyversion => '1.8.7'
+      } }
+      it { is_expected.to contain_file('sssd.conf') \
+        .with_ensure('present') \
+        .with_path('/etc/sssd/sssd.conf') \
+        .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+      }
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,7 +46,7 @@ describe 'sssd' do
         is_expected.to contain_file('sssd.conf') \
           .with_ensure('present') \
           .with_path('/etc/sssd/sssd.conf') \
-          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
       end
     end
   end
@@ -98,7 +98,7 @@ describe 'sssd' do
         is_expected.to contain_file('sssd.conf') \
           .with_ensure('present') \
           .with_path('/etc/sssd/sssd.conf') \
-          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
       end
     end
   end
@@ -150,7 +150,7 @@ describe 'sssd' do
         is_expected.to contain_file('sssd.conf') \
           .with_ensure('present') \
           .with_path('/etc/sssd/sssd.conf') \
-          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
       end
     end
   end
@@ -200,7 +200,7 @@ describe 'sssd' do
         is_expected.to contain_file('sssd.conf') \
           .with_ensure('present') \
           .with_path('/etc/sssd/sssd.conf') \
-          .with_content(/^# Managed by Puppet.\n\n\[domain\/ad.example.com\]/)
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
       end
     end
   end

--- a/templates/sssd.conf.sorted.erb
+++ b/templates/sssd.conf.sorted.erb
@@ -1,9 +1,9 @@
 # Managed by Puppet.
 
-<% @config.map do |k,v| -%>
+<% @config.sort.map do |k,v| -%>
 <%   if v.is_a?(Hash) -%>
 [<%=  k %>]
-<%     v.map do |ki, vi| -%>
+<%     v.sort.map do |ki, vi| -%>
 <%       if vi.is_a?(Array) -%>
 <%=        ki %> = <%= vi.join(', ') %>
 <%       elsif vi != :undef -%>


### PR DESCRIPTION
 * For ruby versions > 1.9.3 use order specified by user for
   configuration, otherwise sort it alphabetically.
 * Remove extraneous whitespace.