### PR TITLE
Added ability to join Active Directory domain(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example configuration:
 class {'::sssd':
   config => {
     'sssd' => {
-      'domains'             => 'ad.example.com',
+      'domains'             => ['ad.example.com'],
       'config_file_version' => 2,
       'services'            => ['nss', 'pam'],
     },
@@ -56,7 +56,8 @@ class {'::sssd':
 ```yaml
 sssd::config:
   'sssd':
-    'domains': 'ad.example.com'
+    'domains':
+      - 'ad.example.com'
     'config_file_version': 2
     'services':
       - 'nss'
@@ -105,12 +106,19 @@ access_provider = simple
 simple_allow_groups = admins, users
 ```
 
-Tip: Using 'ad' as `id_provider` require you to run 'adcli join domain' on the target node. *adcli join* creates a computer account in the domain for the local machine, and sets up a keytab for the machine.
+Tip: Using 'ad' as `id_provider` requires you to pass `ad_join_username`, `ad_join_password`, and `ad_join_ou` parameters.
+This will cause the module to run 'adcli join domain' on the target node which creates a computer account in the domain for the local machine, and sets up a keytab.
 
 Example:
 
-```bash
-$ sudo adcli join ad.example.com
+```puppet
+class {'::sssd':
+  config           => $config,
+  ad_join_username => 'username',
+  ad_join_password => 'secret',
+  ad_join_ou       => 'ou=container,dc=example,dc=com'
+}
+
 ```
 
 ## Reference
@@ -128,8 +136,8 @@ Default:
 config => {
   'sssd' => {
     'config_file_version' => '2',
-    'services'            => 'nss, pam',
-    'domains'             => 'ad.example.com',
+    'services'            => ['nss', 'pam'],
+    'domains'             => ['ad.example.com'],
   },
     'domain/ad.example.com' => {
       'id_provider'       => 'ad',
@@ -143,6 +151,21 @@ config => {
 Set to 'true' to enable auto-creation of home directories on user login.
 Type: boolean
 Default: true
+
+#####`ad_join_username`
+Defines the Active Directory username to use during domain join operations.
+Type: string
+Default: undef
+
+#####`$ad_join_password`
+Defines the Active Directory password to use during domain join operations. hiera-eyaml should be used for secure storage of this password.
+Type: string
+Default: undef
+
+#####`$ad_join_ou`
+Defines the Active Directory organizational unit to use during domain join operations.
+Type: string
+Default: undef
 
 ## Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,9 @@ class sssd::config (
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
+  $ad_join_username        = $sssd::ad_join_username,
+  $ad_join_password        = $sssd::ad_join_password,
+  $ad_join_ou              = $sssd::ad_join_ou,
 ) {
 
   file { 'sssd.conf':
@@ -16,6 +19,15 @@ class sssd::config (
     group   => 'root',
     mode    => '0600',
     content => template($config_template),
+  }
+
+  $sssd_domains = $config[sssd][domains]
+
+  sssd::join_ad_domains { $sssd_domains:
+    config           => $config,
+    ad_join_username => $ad_join_username,
+    ad_join_password => $ad_join_password,
+    ad_join_ou       => $ad_join_ou,
   }
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,12 +29,24 @@
 # [*service_ensure*]
 #   Ensure if services should be running/stopped
 #
+# [*ad_join_username*]
+#   Username to use during AD join operation.
+#   Note: Required parameter when id_provider is set to 'ad'
+#
+# [*ad_join_password*]
+#   Password to use during AD join operation.
+#   Note: Required parameter when id_provider is set to 'ad'
+#
+# [*ad_join_ou*]
+#   OU to use for computer account creation during AD join operation.
+#   Note: Required parameter when id_provider is set to 'ad'
+#
 # === Examples
 #
 # class {'::sssd':
 #   config => {
 #     'sssd' => {
-#       'domains'             => 'ad.example.com',
+#       'domains'             => ['ad.example.com'],
 #       'config_file_version' => 2,
 #       'services'            => ['nss', 'pam'],
 #     }
@@ -78,6 +90,9 @@ class sssd (
   $service_ensure          = $sssd::params::service_ensure,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
+  $ad_join_username        = $sssd::params::ad_join_username,
+  $ad_join_password        = $sssd::params::ad_join_password,
+  $ad_join_ou              = $sssd::params::ad_join_ou,
 ) inherits sssd::params {
 
   validate_re($ensure, '^(present|absent)$',
@@ -87,7 +102,10 @@ class sssd (
   validate_string(
     $sssd_package,
     $sssd_service,
-    $config_template
+    $config_template,
+    $ad_join_username,
+    $ad_join_password,
+    $ad_join_ou
   )
 
   validate_array(

--- a/manifests/join_ad_domains.pp
+++ b/manifests/join_ad_domains.pp
@@ -1,0 +1,29 @@
+# == Defined Type: sssd::join_ad_domains
+#
+# Uses adcli to join to an Active Directory domain.
+#
+# See README.md for more details
+#
+define sssd::join_ad_domains ($config, $ad_join_username, $ad_join_password, $ad_join_ou) {
+  $sssd_domain = $title
+  $id_provider = $config["domain/${sssd_domain}"][id_provider]
+
+  if $id_provider == 'ad' {
+    if $ad_join_username == undef {
+      notify {'For Active Directory join to work you must specify the ad_join_username parameter.':}
+    }
+    elsif $ad_join_password == undef {
+      notify {'For Active Directory join to work you must specify the ad_join_password parameter.':}
+    }
+    elsif $ad_join_ou == undef {
+      notify {'For Active Directory join to work you must specify the ad_join_ou parameter.':}
+    }
+    else {
+      exec {'adcli_join':
+        command   => "/bin/echo -n \'${ad_join_password}\' | /usr/sbin/adcli join --login-user=\'${ad_join_username}\' --domain=\'${sssd_domain}\' --domain-ou=\'${ad_join_ou}\' --stdin-password --verbose",
+        logoutput => true,
+        creates   => '/etc/krb5.keytab',
+      }
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,10 @@ class sssd::params {
     $config_template = "${module_name}/sssd.conf.sorted.erb"
   }
 
+  $ad_join_username = undef
+  $ad_join_password = undef
+  $ad_join_ou       = undef
+
   case $::osfamily {
 
     'RedHat': {
@@ -45,6 +49,7 @@ class sssd::params {
         $extra_packages = [
           'authconfig',
           'oddjob-mkhomedir',
+          'adcli',
         ]
         $extra_packages_ensure = 'present'
         $manage_oddjobd        = true
@@ -63,6 +68,7 @@ class sssd::params {
         'libpam-runtime',
         'libpam-sss',
         'libnss-sss',
+        'adcli',
       ]
       $extra_packages_ensure = 'present'
       $manage_oddjobd        = false


### PR DESCRIPTION
Added ability to join Active Directory domain(s)
* Created `sssd::join_ad_domains` defined type to join domains using the `adcli join` command when `id_provider` is set to `'ad'`
* Updated documentation to show that `domains` is actually an array inside of the `config` hash
* Added documentation for new Active Directory join feature
* Added `adcli` package to RedHat and Debian `$extra_packages` lists