### PR TITLE
Added join domain and pam access support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,9 +4,13 @@ class sssd::config (
   $config                  = $sssd::config,
   $config_file             = $sssd::config_file,
   $config_template         = $sssd::config_template,
+  $base_flags              = $sssd::base_flags,
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
+  $pamaccess               = $sssd::pamaccess,
+  $enable_pamaccess_flags  = $sssd::enable_pamaccess_flags,
+  $disable_pamaccess_flags = $sssd::disable_pamaccess_flags,
   $join_ad_domain          = $sssd::join_ad_domain,
   $ad_domain               = $sssd::ad_domain, 
   $ad_join_user            = $sssd::ad_join_user,
@@ -26,9 +30,15 @@ class sssd::config (
 
     'Redhat': {
 
-      $authconfig_flags = $mkhomedir ? {
+      $authconfig_flags = join($base_flags, ' ')
+
+      $authconfig_flags = $authconfig_flags + $mkhomedir ? {
         true  => join($enable_mkhomedir_flags, ' '),
         false => join($disable_mkhomedir_flags, ' '),
+      }
+      $authconfig_flags = $authconfig_flags + $pamaccess ? {
+        true  => join($enable_pamaccess_flags, ' '),
+        false => join($disable_pamaccess_flags, ' '),
       }
       $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} --update"
       $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} --test"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,9 +8,9 @@ class sssd::config (
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
-  $pamaccess               = $sssd::pamaccess,
-  $enable_pamaccess_flags  = $sssd::enable_pamaccess_flags,
-  $disable_pamaccess_flags = $sssd::disable_pamaccess_flags,
+  $pam_access               = $sssd::pam_access,
+  $enable_pam_access_flags  = $sssd::enable_pam_access_flags,
+  $disable_pam_access_flags = $sssd::disable_pam_access_flags,
   $join_ad_domain          = $sssd::join_ad_domain,
   $ad_domain               = $sssd::ad_domain, 
   $ad_join_user            = $sssd::ad_join_user,
@@ -36,12 +36,12 @@ class sssd::config (
         true  => join($enable_mkhomedir_flags, ' '),
         false => join($disable_mkhomedir_flags, ' '),
       }
-      $authconfig_pamaccess_flags = $pamaccess ? {
-        true  => join($enable_pamaccess_flags, ' '),
-        false => join($disable_pamaccess_flags, ' '),
+      $authconfig_pam_access_flags = $pam_access ? {
+        true  => join($enable_pam_access_flags, ' '),
+        false => join($disable_pam_access_flags, ' '),
       }
 
-      $authconfig_flags = "${authconfig_base_flags} ${authconfig_mkhomedir_flags} ${authconfig_pamaccess_flags}"
+      $authconfig_flags = "${authconfig_base_flags} ${authconfig_mkhomedir_flags} ${authconfig_pam_access_flags}"
 
       $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} --update"
       $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} --test"
@@ -52,7 +52,7 @@ class sssd::config (
         unless  => $authconfig_check_cmd,
       }
 
-      if $join_ad_domain {
+      if $join_ad_domain and $ad_domain and $ad_join_user and $ad_join_pass {
         package { 'adcli':
           ensure => present,
         }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ class sssd::config (
         unless  => $authconfig_check_cmd,
       }
 
-      if $join_ad_domain == 'true' {
+      if $join_ad_domain {
         package { 'adcli':
           ensure => present,
         }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,16 +30,19 @@ class sssd::config (
 
     'Redhat': {
 
-      $authconfig_flags = join($base_flags, ' ')
+      $authconfig_base_flags = join($base_flags, ' ')
 
-      $authconfig_flags = $authconfig_flags + $mkhomedir ? {
+      $authconfig_mkhomedir_flags = $mkhomedir ? {
         true  => join($enable_mkhomedir_flags, ' '),
         false => join($disable_mkhomedir_flags, ' '),
       }
-      $authconfig_flags = $authconfig_flags + $pamaccess ? {
+      $authconfig_pamaccess_flags = $pamaccess ? {
         true  => join($enable_pamaccess_flags, ' '),
         false => join($disable_pamaccess_flags, ' '),
       }
+
+      $authconfig_flags = "${authconfig_base_flags} ${authconfig_mkhomedir_flags} ${authconfig_pamaccess_flags}"
+
       $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} --update"
       $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} --test"
       $authconfig_check_cmd  = "/usr/bin/test \"`${authconfig_test_cmd}`\" = \"`/usr/sbin/authconfig --test`\""

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,7 +52,7 @@ class sssd::config (
         unless  => $authconfig_check_cmd,
       }
 
-      if $join_ad_domain and $ad_domain and $ad_join_user and $ad_join_pass {
+      if $join_ad_domain {
         package { 'adcli':
           ensure => present,
         }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ class sssd::config (
   $enable_pam_access_flags  = $sssd::enable_pam_access_flags,
   $disable_pam_access_flags = $sssd::disable_pam_access_flags,
   $join_ad_domain          = $sssd::join_ad_domain,
-  $ad_domain               = $sssd::ad_domain, 
+  $ad_domain               = $sssd::ad_domain,
   $ad_join_user            = $sssd::ad_join_user,
   $ad_join_pass            = $sssd::ad_join_pass,
 ) {
@@ -60,7 +60,7 @@ class sssd::config (
           command => "/bin/echo -n '${ad_join_pass}' |  /usr/sbin/adcli join ${ad_domain} -U ${ad_join_user} --stdin-password",
           creates => '/etc/krb5.keytab',
           require => Package['adcli'],
-        } 
+        }
         Exec[ 'authconfig-mkhomedir' ] -> File[ 'sssd.conf' ] -> Exec[ 'join-computer-to-domain' ]
       }
       else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class sssd::config (
   $join_ad_domain          = $sssd::join_ad_domain,
   $ad_domain               = $sssd::ad_domain, 
   $ad_join_user            = $sssd::ad_join_user,
-  $ad_join_pass            = $ad_join_pass,
+  $ad_join_pass            = $sssd::ad_join_pass,
 ) {
 
   file { 'sssd.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,15 +73,19 @@ class sssd (
   $extra_packages_ensure   = $sssd::params::extra_packages_ensure,
   $config_file             = $sssd::params::config_file,
   $config_template         = $sssd::params::config_template,
+  $base_flags              = $sssd::params::base_flags,
   $mkhomedir               = $sssd::params::mkhomedir,
   $manage_oddjobd          = $sssd::params::manage_oddjobd,
   $service_ensure          = $sssd::params::service_ensure,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
-  $join_ad_domain          = false,
-  $ad_domain               = undef,
-  $ad_join_user            = undef,
-  $ad_join_pass            = undef,
+  $pamaccess               = $sssd::params::pamaccess,
+  $enable_pamaccess_flags  = $sssd::params::enable_pamaccess_flags,
+  $disable_pamaccess_flags = $sssd::params::disable_pamaccess_flags,
+  $join_ad_domain          = $sssd::params::join_ad_domain,
+  $ad_domain               = $sssd::params::ad_domain,
+  $ad_join_user            = $sssd::params::ad_join_user,
+  $ad_join_pass            = $sssd::params::ad_join_pass
 
 ) inherits sssd::params {
 
@@ -100,8 +104,11 @@ class sssd (
 
   validate_array(
     $extra_packages,
+    $base_flags,
     $enable_mkhomedir_flags,
-    $disable_mkhomedir_flags
+    $disable_mkhomedir_flags,
+    $enable_pamaccess_flags,
+    $disable_pamaccess_flags
   )
 
   validate_absolute_path(
@@ -110,6 +117,7 @@ class sssd (
 
   validate_bool(
     $mkhomedir,
+    $pamaccess,
     $join_ad_domain
   )
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,9 @@
 # [*extra_packages*]
 #   Array with extra packages to be installed
 #
+# [*$base_flags*]
+#   Array with flags to use with authconfig for basic settings.
+#
 # [*mkhomedir*]
 #   Boolean. Manage auto-creation of home directories on user login.
 #
@@ -28,6 +31,27 @@
 #
 # [*service_ensure*]
 #   Ensure if services should be running/stopped
+#
+# [*pam_access*]
+#   Boolean. Manage pam_access configuration
+#
+# [*enable_pam_access_flags*]
+#   Flags to use with authconfig to enable pam_access.
+#
+# [*disable_pam_access_flags*]
+#   Flags to use with authconfig to disable pam_access.
+#
+# [*join_ad_domain*]
+#   Boolean. Join Active Directory.  Requires ad_domain, ad_join_user and ad_join_pass.
+#
+# [*ad_domain*]
+#   Active Directory domain to join.
+#
+# [*ad_join_user*]
+#   Active Directory user with permissions to add computer to domain.
+#
+# [*join_ad_pass*]
+#   Password for ad_join_user.
 #
 # === Examples
 #
@@ -65,27 +89,27 @@
 # Copyright 2015 Gjermund Jensvoll
 #
 class sssd (
-  $ensure                  = $sssd::params::ensure,
-  $config                  = $sssd::params::config,
-  $sssd_package            = $sssd::params::sssd_package,
-  $sssd_service            = $sssd::params::sssd_service,
-  $extra_packages          = $sssd::params::extra_packages,
-  $extra_packages_ensure   = $sssd::params::extra_packages_ensure,
-  $config_file             = $sssd::params::config_file,
-  $config_template         = $sssd::params::config_template,
-  $base_flags              = $sssd::params::base_flags,
-  $mkhomedir               = $sssd::params::mkhomedir,
-  $manage_oddjobd          = $sssd::params::manage_oddjobd,
-  $service_ensure          = $sssd::params::service_ensure,
-  $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
-  $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
-  $pamaccess               = $sssd::params::pamaccess,
-  $enable_pamaccess_flags  = $sssd::params::enable_pamaccess_flags,
-  $disable_pamaccess_flags = $sssd::params::disable_pamaccess_flags,
-  $join_ad_domain          = $sssd::params::join_ad_domain,
-  $ad_domain               = $sssd::params::ad_domain,
-  $ad_join_user            = $sssd::params::ad_join_user,
-  $ad_join_pass            = $sssd::params::ad_join_pass
+  $ensure                   = $sssd::params::ensure,
+  $config                   = $sssd::params::config,
+  $sssd_package             = $sssd::params::sssd_package,
+  $sssd_service             = $sssd::params::sssd_service,
+  $extra_packages           = $sssd::params::extra_packages,
+  $extra_packages_ensure    = $sssd::params::extra_packages_ensure,
+  $config_file              = $sssd::params::config_file,
+  $config_template          = $sssd::params::config_template,
+  $base_flags               = $sssd::params::base_flags,
+  $mkhomedir                = $sssd::params::mkhomedir,
+  $manage_oddjobd           = $sssd::params::manage_oddjobd,
+  $service_ensure           = $sssd::params::service_ensure,
+  $enable_mkhomedir_flags   = $sssd::params::enable_mkhomedir_flags,
+  $disable_mkhomedir_flags  = $sssd::params::disable_mkhomedir_flags,
+  $pam_access               = $sssd::params::pam_access,
+  $enable_pam_access_flags  = $sssd::params::enable_pam_access_flags,
+  $disable_pam_access_flags = $sssd::params::disable_pam_access_flags,
+  $join_ad_domain           = $sssd::params::join_ad_domain,
+  $ad_domain                = $sssd::params::ad_domain,
+  $ad_join_user             = $sssd::params::ad_join_user,
+  $ad_join_pass             = $sssd::params::ad_join_pass
 
 ) inherits sssd::params {
 
@@ -107,8 +131,8 @@ class sssd (
     $base_flags,
     $enable_mkhomedir_flags,
     $disable_mkhomedir_flags,
-    $enable_pamaccess_flags,
-    $disable_pamaccess_flags
+    $enable_pam_access_flags,
+    $disable_pam_access_flags
   )
 
   validate_absolute_path(
@@ -117,7 +141,7 @@ class sssd (
 
   validate_bool(
     $mkhomedir,
-    $pamaccess,
+    $pam_access,
     $join_ad_domain
   )
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,11 @@ class sssd (
   $service_ensure          = $sssd::params::service_ensure,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
+  $join_ad_domain          = false,
+  $ad_domain               = undef,
+  $ad_join_user            = undef,
+  $ad_join_pass            = undef,
+
 ) inherits sssd::params {
 
   validate_re($ensure, '^(present|absent)$',
@@ -87,7 +92,10 @@ class sssd (
   validate_string(
     $sssd_package,
     $sssd_service,
-    $config_template
+    $config_template,
+    $ad_domain,
+    $ad_join_user,
+    $ad_join_pass
   )
 
   validate_array(
@@ -101,7 +109,8 @@ class sssd (
   )
 
   validate_bool(
-    $mkhomedir
+    $mkhomedir,
+    $join_ad_domain
   )
 
   validate_hash(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class sssd::params {
       'cache_credentials' => true,
     },
   }
-  $default_flags           = ['--enablesssd', '--enablesssdauth']
+  $base_flags              = ['--enablesssd', '--enablesssdauth']
   $enable_mkhomedir_flags  = ['--enablemkhomedir']
   $disable_mkhomedir_flags = ['--disablemkhomedir']
   $enable_pamaccess_flags  = ['--enablepamaccess']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,16 +14,11 @@ class sssd::params {
       'cache_credentials' => true,
     },
   }
-  $base_flags              = ['--enablesssd', '--enablesssdauth']
-  $enable_mkhomedir_flags  = ['--enablemkhomedir']
-  $disable_mkhomedir_flags = ['--disablemkhomedir']
-  $enable_pamaccess_flags  = ['--enablepamaccess']
-  $disable_pamaccess_flags = ['--disablepamaccess']
-  $pamaccess               = false
-  $join_ad_domain          = false
-  $ad_domain               = undef
-  $ad_join_user            = undef
-  $ad_join_pass            = undef
+  $base_flags               = ['--enablesssd', '--enablesssdauth']
+  $enable_mkhomedir_flags   = ['--enablemkhomedir']
+  $disable_mkhomedir_flags  = ['--disablemkhomedir']
+  $enable_pam_access_flags  = ['--enablepamaccess']
+  $disable_pam_access_flags = ['--disablepamaccess']
 
   # Earlier versions of ruby didn't provide ordered hashs, so we need to sort
   # the configuration ourselves to ensure a consistent config file.
@@ -42,6 +37,11 @@ class sssd::params {
       $service_ensure = 'running'
       $config_file    = '/etc/sssd/sssd.conf'
       $mkhomedir      = true
+      $pam_access     = false
+      $join_ad_domain = false
+      $ad_domain      = undef
+      $ad_join_user   = undef
+      $ad_join_pass   = undef
 
       if versioncmp($::operatingsystemrelease, '6.0') < 0 {
         $extra_packages = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,8 +14,16 @@ class sssd::params {
       'cache_credentials' => true,
     },
   }
-  $enable_mkhomedir_flags  = ['--enablesssd', '--enablesssdauth', '--enablemkhomedir']
-  $disable_mkhomedir_flags = ['--enablesssd', '--enablesssdauth', '--disablemkhomedir']
+  $default_flags           = ['--enablesssd', '--enablesssdauth']
+  $enable_mkhomedir_flags  = ['--enablemkhomedir']
+  $disable_mkhomedir_flags = ['--disablemkhomedir']
+  $enable_pamaccess_flags  = ['--enablepamaccess']
+  $disable_pamaccess_flags = ['--disablepamaccess']
+  $pamaccess               = false
+  $join_ad_domain          = false
+  $ad_domain               = undef
+  $ad_join_user            = undef
+  $ad_join_pass            = undef
 
   # Earlier versions of ruby didn't provide ordered hashs, so we need to sort
   # the configuration ourselves to ensure a consistent config file.


### PR DESCRIPTION
These have been verified to work on Centos 7.  System is able to successfully join the domain and create a krb5.keytab file.  Pam access can be optionally enabled if it is desirable to manage security via security.conf.