### PR TITLE
Fix Service[oddjobd] failing to start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ group :unit_tests do
   gem 'puppetlabs_spec_helper',                           :require => false
   gem 'rspec-puppet-facts',                               :require => false
   gem 'metadata-json-lint',                               :require => false
-  gem 'json',                                             :require => false
   gem 'puppet-lint-trailing_newline-check',               :require => false
   gem 'puppet-lint-variable_contains_upcase',             :require => false
   gem 'puppet-lint-absolute_template_path',               :require => false
@@ -44,6 +43,21 @@ if (puppetversion = ENV['PUPPET_GEM_VERSION'])
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', '~> 3.8', :require => false
+end
+
+# Fix Travis failures related to MRI <> Gem compatibilities.
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  # rspec must be v2 for ruby 1.8.7
+  gem 'rspec', '~> 2.0'
+  # rake >= 11 does not support ruby 1.8.7
+  gem 'rake', '~> 10.0'
+end
+
+if RUBY_VERSION < '2.0'
+  # json 2.x requires ruby 2.0. Lock to 1.8
+  gem 'json', '~> 1.8'
+  # json_pure 2.0.2 requires ruby 2.0. Lock to 2.0.1
+  gem 'json_pure', '= 2.0.1'
 end
 
 # vim:ft=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ else
 end
 
 # Fix Travis failures related to MRI <> Gem compatibilities.
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
   # rspec must be v2 for ruby 1.8.7
   gem 'rspec', '~> 2.0'
   # rake >= 11 does not support ruby 1.8.7

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,11 @@
 # [*service_ensure*]
 #   Ensure if services should be running/stopped
 #
+# [*service_dependencies*]
+#   Array of service resource names to manage before managing sssd related
+#   services.  Intended to be used to manage messagebus service to prevent
+#   `Error: Could not start Service[oddjobd]`.
+#
 # === Examples
 #
 # class {'::sssd':
@@ -76,6 +81,7 @@ class sssd (
   $mkhomedir               = $sssd::params::mkhomedir,
   $manage_oddjobd          = $sssd::params::manage_oddjobd,
   $service_ensure          = $sssd::params::service_ensure,
+  $service_dependencies    = $sssd::params::service_dependencies,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
 ) inherits sssd::params {
@@ -93,7 +99,8 @@ class sssd (
   validate_array(
     $extra_packages,
     $enable_mkhomedir_flags,
-    $disable_mkhomedir_flags
+    $disable_mkhomedir_flags,
+    $service_dependencies
   )
 
   validate_absolute_path(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class sssd::params {
       $sssd_package   = 'sssd'
       $sssd_service   = 'sssd'
       $service_ensure = 'running'
+      $service_dependencies = ['messagebus']
       $config_file    = '/etc/sssd/sssd.conf'
       $mkhomedir      = true
 
@@ -57,6 +58,7 @@ class sssd::params {
       $sssd_package   = 'sssd'
       $sssd_service   = 'sssd'
       $service_ensure = 'running'
+      $service_dependencies = []
       $config_file    = '/etc/sssd/sssd.conf'
       $mkhomedir      = true
       $extra_packages = [

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,22 @@
 # See README.md for usage information
 class sssd::service (
-  $sssd_service   = $sssd::sssd_service,
-  $mkhomedir      = $sssd::mkhomedir,
-  $manage_oddjobd = $sssd::manage_oddjobd,
-  $service_ensure = $sssd::service_ensure,
+  $sssd_service         = $sssd::sssd_service,
+  $mkhomedir            = $sssd::mkhomedir,
+  $manage_oddjobd       = $sssd::manage_oddjobd,
+  $service_dependencies = $sssd::service_dependencies,
+  $service_ensure       = $sssd::service_ensure,
 ) {
+
+  if ! empty($service_dependencies) {
+    service { $service_dependencies:
+      ensure     => running,
+      hasstatus  => true,
+      hasrestart => true,
+      enable     => true,
+      before     => Service[$sssd_service],
+    }
+  }
+
   service { $sssd_service:
     ensure     => $service_ensure,
     enable     => true,


### PR DESCRIPTION
Without this patch the initial Puppet run fails with the following error
message:

    Error: Could not start Service[oddjobd]: Execution of '/sbin/service oddjobd
    start' returned 1: Starting oddjobd: [FAILED]

The cause of this error is that the `messagebus` service is not started.  This
patch addresses the problem by adding optional management of dependent services
to the sssd::services class.  Since these dependencies aren't strictly related
to sssd they can easily be overridden by setting sssd::service_dependencies to
an empty array in Hiera.