### PR TITLE
Added ensure_resource and ensure_packages to avoid collisions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,15 +22,14 @@ group :unit_tests do
 end
 
 group :development do
-  gem 'simplecov',        :require => false
+  gem 'simplecov', :require => false
   # gem 'guard-rake',       :require => false
   gem 'librarian-puppet', :require => false
 end
 
 group :system_tests do
   # gem 'vagrant-wrapper', :require => false
-  gem 'beaker-rspec',    :require => false
-  gem 'serverspec',      :require => false
+  gem 'serverspec', :require => false
 end
 
 if (facterversion = ENV['FACTER_GEM_VERSION'])
@@ -60,4 +59,10 @@ if RUBY_VERSION < '2.0'
   gem 'json_pure', '= 2.0.1'
 end
 
+if RUBY_VERSION < '2.2.5'
+  # beaker 3.1+ requires ruby 2.2.5.  Lock to 2.0
+  gem 'beaker', '~> 2.0', :require => false
+  # beaker-rspec 6.0.0 requires beaker 3.0. Lock to 5.6.0
+  gem 'beaker-rspec', '= 5.6.0', :require => false
+end
 # vim:ft=ruby

--- a/examples/ad.pp
+++ b/examples/ad.pp
@@ -1,6 +1,6 @@
 class {'::sssd':
   config => {
-    'sssd' => {
+    'sssd'                  => {
       'domains'             => 'ad.example.com',
       'config_file_version' => 2,
       'services'            => ['nss', 'pam'],

--- a/examples/ipa.pp
+++ b/examples/ipa.pp
@@ -1,6 +1,6 @@
 class {'::sssd':
   config => {
-    'sssd' => {
+    'sssd'                  => {
       'domains'             => 'example.com',
       'config_file_version' => 2,
       'services'            => ['nss', 'sudo', 'pam', 'ssh'],

--- a/examples/ldap.pp
+++ b/examples/ldap.pp
@@ -1,6 +1,6 @@
 class {'::sssd':
   config => {
-    'sssd' => {
+    'sssd'               => {
       'domains'             => 'example.com',
       'config_file_version' => 2,
       'services'            => ['nss', 'pam'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,9 +123,7 @@ class sssd (
   validate_re($service_ensure, '^running|true|stopped|false$')
 
   anchor { 'sssd::begin': } ->
-  class { '::sssd::install':
-    ensure => $sssd_package_ensure,
-  } ->
+  class { '::sssd::install': } ->
   class { '::sssd::config': } ~>
   class { '::sssd::service': } ->
   anchor { 'sssd::end': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,9 @@ class sssd (
   validate_re($service_ensure, '^running|true|stopped|false$')
 
   anchor { 'sssd::begin': } ->
-  class { '::sssd::install': } ->
+  class { '::sssd::install':
+    ensure => $sssd_package_ensure,
+  } ->
   class { '::sssd::config': } ~>
   class { '::sssd::service': } ->
   anchor { 'sssd::end': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # See README.md for usage information
 class sssd::install (
-  $sssd_package_ensure   = $sssd::sssd_package_ensure,
   $sssd_package          = $sssd::sssd_package,
+  $sssd_package_ensure   = $sssd::sssd_package_ensure,
   $extra_packages        = $sssd::extra_packages,
   $extra_packages_ensure = $sssd::extra_packages_ensure,
 ) {
@@ -10,7 +10,8 @@ class sssd::install (
 
   if $extra_packages {
     ensure_packages($extra_packages,
-      { ensure => $extra_packages_ensure,
+      {
+        ensure => $extra_packages_ensure,
         require => Package[$sssd_package],
       }
     )

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class sssd::install (
   $extra_packages_ensure = $sssd::extra_packages_ensure,
 ) {
 
-  ensure_packages([$sssd_package],{ ensure => $ensure })
+  ensure_packages({$sssd_package => { 'ensure' => $ensure } } )
 
   if $extra_packages {
     ensure_packages($extra_packages,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class sssd::install (
   if $extra_packages {
     ensure_packages($extra_packages,
       { ensure => $extra_packages_ensure,
-      require => Package[$sssd_package],
+        require => Package[$sssd_package],
       }
     )
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,12 @@
 # See README.md for usage information
 class sssd::install (
-  $ensure                = $sssd::ensure,
+  $sssd_package_ensure   = $sssd::sssd_package_ensure,
   $sssd_package          = $sssd::sssd_package,
   $extra_packages        = $sssd::extra_packages,
   $extra_packages_ensure = $sssd::extra_packages_ensure,
 ) {
 
-  ensure_packages({$sssd_package => { 'ensure' => $ensure } } )
+  ensure_resource('package', $sssd_package, { ensure =>  $sssd_package_ensure })
 
   if $extra_packages {
     ensure_packages($extra_packages,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,20 +1,18 @@
 # See README.md for usage information
 class sssd::install (
+  $ensure                = $sssd::ensure,
   $sssd_package          = $sssd::sssd_package,
-  $sssd_package_ensure   = $sssd::sssd_package_ensure,
   $extra_packages        = $sssd::extra_packages,
   $extra_packages_ensure = $sssd::extra_packages_ensure,
 ) {
 
-  package { $sssd_package:
-    ensure => $sssd_package_ensure,
-  }
+  ensure_packages([$sssd_package],{ ensure => $ensure })
 
   if $extra_packages {
-    package { $extra_packages:
-      ensure  => $extra_packages_ensure,
+    ensure_packages($extra_packages,
+      { ensure => $extra_packages_ensure,
       require => Package[$sssd_package],
-    }
+      }
+    )
   }
-
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,32 +8,35 @@ class sssd::service (
 ) {
 
   if ! empty($service_dependencies) {
-    service { $service_dependencies:
-      ensure     => running,
-      hasstatus  => true,
-      hasrestart => true,
-      enable     => true,
-      before     => Service[$sssd_service],
-    }
+    ensure_resource('service', $service_dependencies,
+      {
+        ensure     => running,
+        hasstatus  => true,
+        hasrestart => true,
+        enable     => true,
+        before     => Service[$sssd_service],
+      }
+    )
   }
 
-  service { $sssd_service:
-    ensure     => $service_ensure,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
-  }
-
-  if $mkhomedir and $manage_oddjobd {
-
-    service { 'oddjobd':
+  ensure_resource('service', $sssd_service,
+    {
       ensure     => $service_ensure,
       enable     => true,
       hasstatus  => true,
       hasrestart => true,
-      require    => Service[$sssd_service],
     }
+  )
 
+  if $mkhomedir and $manage_oddjobd {
+    ensure_resource('service', 'oddjobd',
+      {
+        ensure     => $service_ensure,
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        require    => Service[$sssd_service],
+      }
+    )
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 < 5.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0 < 5.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.3.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0 < 5.0.0"}
   ]
 }


### PR DESCRIPTION
Needs newer version of puppetlabs-stdlib which I have added to the metadata.json.

Puppetlabs-stdlib 4.x [only works with Puppet 3.x](https://github.com/puppetlabs/puppetlabs-stdlib/tree/4.1.0#compatibility) which is already a minimum requirement for this module.