### PR TITLE
Setting ensure => absent now further disables sssd

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class sssd::config (
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
+  $ensure_absent_flags     = $sssd::ensure_absent_flags,
 ) {
 
   file { 'sssd.conf':
@@ -22,10 +23,16 @@ class sssd::config (
 
     'Redhat': {
 
-      $authconfig_flags = $mkhomedir ? {
-        true  => join($enable_mkhomedir_flags, ' '),
-        false => join($disable_mkhomedir_flags, ' '),
+      if $ensure == 'present' {
+        $authconfig_flags = $mkhomedir ? {
+          true  => join($enable_mkhomedir_flags, ' '),
+          false => join($disable_mkhomedir_flags, ' '),
+        }
       }
+      else {
+        $authconfig_flags = join($ensure_absent_flags, ' ')
+      }
+
       $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} --update"
       $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} --test"
       $authconfig_check_cmd  = "/usr/bin/test \"`${authconfig_test_cmd}`\" = \"`/usr/sbin/authconfig --test`\""

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ class sssd (
   $service_dependencies    = $sssd::params::service_dependencies,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::params::disable_mkhomedir_flags,
+  $ensure_absent_flags     = $sssd::params::ensure_absent_flags,
 ) inherits sssd::params {
 
   validate_re($ensure, '^(present|absent)$',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class sssd::params {
   }
   $enable_mkhomedir_flags  = ['--enablesssd', '--enablesssdauth', '--enablemkhomedir']
   $disable_mkhomedir_flags = ['--enablesssd', '--enablesssdauth', '--disablemkhomedir']
+  $ensure_absent_flags = ['--disablesssd', '--disablesssdauth']
 
   # Earlier versions of ruby didn't provide ordered hashs, so we need to sort
   # the configuration ourselves to ensure a consistent config file.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,13 +1,20 @@
 # See README.md for usage information
 class sssd::service (
   $sssd_service         = $sssd::sssd_service,
-  $service_ensure       = $sssd::service_ensure,
+  $service_ensure       = $sssd::ensure ? {
+    absent      => "stopped",
+    default     => $sssd::service_ensure,
+    }
 ) {
 
+  $service_enable = $service_ensure ? {
+      stopped    => false,
+      default   => true,
+  }
   ensure_resource('service', $sssd_service,
     {
       ensure     => $service_ensure,
-      enable     => true,
+      enable     => $service_enable,
       hasstatus  => true,
       hasrestart => true,
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,14 +2,14 @@
 class sssd::service (
   $sssd_service         = $sssd::sssd_service,
   $service_ensure       = $sssd::ensure ? {
-    absent      => 'stopped',
+    'absent'      => 'stopped',
     default     => $sssd::service_ensure,
-    }
+  }
 ) {
 
   $service_enable = $service_ensure ? {
-      stopped    => false,
-      default   => true,
+    'stopped'    => false,
+    default   => true,
   }
   ensure_resource('service', $sssd_service,
     {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@
 class sssd::service (
   $sssd_service         = $sssd::sssd_service,
   $service_ensure       = $sssd::ensure ? {
-    absent      => "stopped",
+    absent      => 'stopped',
     default     => $sssd::service_ensure,
     }
 ) {


### PR DESCRIPTION
* For redhat-based systems, authconfig flags --disablesssd and --disablesssdauth
* The sssd service sets ensure => stopped and enable => false