### PR TITLE
Support Puppet v4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.6.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4.7.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4.8.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.9.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4" CHECK=test
     - PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
 
@@ -52,6 +53,10 @@ matrix:
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.8.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.9.0" CHECK=test
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4" CHECK=test
+    - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
@@ -72,7 +77,7 @@ matrix:
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.8.0" CHECK=test
     - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0" CHECK=build DEPLOY_TO_FORGE=yes 
+      env: PUPPET_GEM_VERSION="~> 3.8.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes" CHECK=test
 


### PR DESCRIPTION
Puppet 4.9 no longer supports Ruby versions 1.9.3 and 2.0.0.