### PR TITLE
Enable support for pam_access

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class sssd::config (
   $mkhomedir               = $sssd::mkhomedir,
   $enable_mkhomedir_flags  = $sssd::enable_mkhomedir_flags,
   $disable_mkhomedir_flags = $sssd::disable_mkhomedir_flags,
+  $pamaccess               = $sssd::pamaccess,
 ) {
 
   file { 'sssd.conf':
@@ -26,8 +27,14 @@ class sssd::config (
         true  => join($enable_mkhomedir_flags, ' '),
         false => join($disable_mkhomedir_flags, ' '),
       }
-      $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} --update"
-      $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} --test"
+
+      $pamaccess_flag = $pamaccess ? {
+        true  => '--enablepamaccess',
+        false => '--disablepamaccess',
+      }
+
+      $authconfig_update_cmd = "/usr/sbin/authconfig ${authconfig_flags} ${pamaccess_flag} --update"
+      $authconfig_test_cmd   = "/usr/sbin/authconfig ${authconfig_flags} ${pamaccess_flag} --test"
       $authconfig_check_cmd  = "/usr/bin/test \"`${authconfig_test_cmd}`\" = \"`/usr/sbin/authconfig --test`\""
 
       exec { 'authconfig-mkhomedir':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 # [*mkhomedir*]
 #   Boolean. Manage auto-creation of home directories on user login.
 #
+# [*pamaccess*]
+#   Boolean. Check access.conf during account authorization.
+#
 # [*manage_oddjobd*]
 #   Boolean. Manage the oddjobd service.
 #
@@ -64,6 +67,7 @@ class sssd (
   $config_template         = $sssd::params::config_template,
   $mkhomedir               = $sssd::params::mkhomedir,
   $manage_oddjobd          = $sssd::params::manage_oddjobd,
+  $pamaccess               = $sssd::params::pamacesss,
   $service_ensure          = $sssd::params::service_ensure,
   $service_dependencies    = $sssd::params::service_dependencies,
   $enable_mkhomedir_flags  = $sssd::params::enable_mkhomedir_flags,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class sssd::params {
       $service_ensure = 'running'
       $config_file    = '/etc/sssd/sssd.conf'
       $mkhomedir      = true
+      $pamaccess      = false
 
       if versioncmp($::operatingsystemrelease, '6.0') < 0 {
         $service_dependencies = ['messagebus']


### PR DESCRIPTION
Only enabled for and tested on RedHat family of systems.