### PR TITLE
Add Suse 11.3, 11.4 and 12.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.7.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4.8.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4.9.0" CHECK=test
+    - PUPPET_GEM_VERSION="~> 4.10.0" CHECK=test
     - PUPPET_GEM_VERSION="~> 4" CHECK=test
 
 sudo: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,6 +66,25 @@ class sssd::config (
 
     }
 
+    'Suse': {
+      $pamconfig_mkhomedir_check_cmd  = '/usr/sbin/pam-config -q --mkhomedir | grep session:'
+      $pamconfig_check_cmd  = '/usr/sbin/pam-config -q --sss | grep session:'
+
+      if $mkhomedir {
+
+        exec { 'pam-config -a --mkhomedir':
+          path   => '/bin:/usr/bin:/sbin:/usr/sbin',
+          unless => $pamconfig_mkhomedir_check_cmd,
+        }
+      }
+
+      exec { 'pam-config -a --sss':
+        path   => '/bin:/usr/bin:/sbin:/usr/sbin',
+        unless => $pamconfig_check_cmd,
+      }
+
+    }
+
     default: { }
 
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,50 @@ class sssd::params {
       ]
       $extra_packages_ensure = 'present'
       $manage_oddjobd        = false
+    }
 
+    'Suse': {
+
+      $sssd_package   = 'sssd'
+      $sssd_service   = 'sssd'
+      $service_ensure = 'running'
+      $config_file    = '/etc/sssd/sssd.conf'
+      $mkhomedir      = true
+      #case $::operatingsystemrelease {
+      case $::operatingsystemmajrelease {
+        default: {
+          fail("operatingsystemrelease is <${::operatingsystemmajrelease}> and must be in 11 or 12.")
+        }
+        '11': {
+          case $::operatingsystemrelease {
+            default: {
+              fail("operatingsystemrelease is <${::operatingsystemrelease}> and must be in 11.3 or 11.4.")
+            }
+            /^11.[34]/: {
+              $service_dependencies = []
+              $extra_packages = [
+                'sssd-32bit',
+                'sssd-tools',
+              ]
+              $extra_packages_ensure = 'present'
+              $manage_oddjobd        = false
+            }
+          }
+        }
+        '12': {
+          $service_dependencies = []
+          $extra_packages = [
+            'sssd-krb5',
+            'sssd-ad',
+            'sssd-ipa',
+            'sssd-32bit',
+            'sssd-tools',
+            'sssd-ldap',
+          ]
+          $extra_packages_ensure = 'present'
+          $manage_oddjobd        = false
+        }
+      }
     }
 
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,10 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": ["7", "8"]
+    },
+    {
+      "operatingsystem": "Suse",
+      "operatingsystemrelease": ["11", "12"]
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -267,4 +267,122 @@ describe 'sssd' do
       it { is_expected.to contain_package('sssd').with_ensure('1.1.1') }
     end
   end
+  describe 'on Suse 11.4' do
+    let(:facts) do
+      {
+        :osfamily => 'Suse',
+        :operatingsystem => 'SLES',
+        :operatingsystemrelease => '11.4',
+        :operatingsystemmajrelease => '11',
+        :rubyversion => '2.1.9',
+      }
+    end
+
+    context 'with defaults for all parameters' do
+      it { is_expected.to contain_class('sssd::install') }
+      it { is_expected.to contain_class('sssd::config') }
+      it { is_expected.to contain_class('sssd::service') }
+
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
+
+      it { is_expected.to contain_package('sssd-32bit').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-tools').with_ensure('present') }
+
+      it { is_expected.to contain_service('sssd').with_ensure('running') }
+      it { is_expected.to contain_package('sssd').with_ensure('present') }
+    end
+
+    context 'with service ensure stopped' do
+      let(:params) { { :service_ensure => 'stopped' } }
+      it { is_expected.to contain_service('sssd').with_ensure('stopped') }
+    end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) do
+        {
+          :osfamily => 'Suse',
+          :operatingsystem => 'SLES',
+          :operatingsystemrelease => '11.4',
+          :operatingsystemmajrelease => '11',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
+      end
+    end
+    context 'with package_ensure set to specific version' do
+      let(:params) { { :sssd_package_ensure => '1.1.1' } }
+      it { is_expected.to contain_package('sssd').with_ensure('1.1.1') }
+    end
+  end
+  describe 'on Suse 12.1' do
+    let(:facts) do
+      {
+        :osfamily => 'Suse',
+        :operatingsystem => 'SLES',
+        :operatingsystemrelease => '12.1',
+        :operatingsystemmajrelease => '12',
+        :rubyversion => '2.1.9',
+      }
+    end
+
+    context 'with defaults for all parameters' do
+      it { is_expected.to contain_class('sssd::install') }
+      it { is_expected.to contain_class('sssd::config') }
+      it { is_expected.to contain_class('sssd::service') }
+
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
+      
+      it { is_expected.to contain_package('sssd-krb5').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-ad').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-ipa').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-32bit').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-tools').with_ensure('present') }
+      it { is_expected.to contain_package('sssd-ldap').with_ensure('present') }
+
+      it { is_expected.to contain_service('sssd').with_ensure('running') }
+      it { is_expected.to contain_package('sssd').with_ensure('present') }
+    end
+
+    context 'with service ensure stopped' do
+      let(:params) { { :service_ensure => 'stopped' } }
+      it { is_expected.to contain_service('sssd').with_ensure('stopped') }
+    end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) do
+        {
+          :osfamily => 'Suse',
+          :operatingsystem => 'SLES',
+          :operatingsystemrelease => '12.1',
+          :operatingsystemmajrelease => '12',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
+      end
+    end
+    context 'with package_ensure set to specific version' do
+      let(:params) { { :sssd_package_ensure => '1.1.1' } }
+      it { is_expected.to contain_package('sssd').with_ensure('1.1.1') }
+    end
+  end
 end


### PR DESCRIPTION
Add support for SUSE/SLES 11.3, 11.4 and 12.X.
Added travis test for puppet 4.1.0.0
Add spec file tests for SUSE/SLES 11.3, 11.4 and 12.X.