### PR TITLE
Gentoo support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,6 +155,19 @@ class sssd::params {
       }
     }
 
+    'Gentoo': {
+
+      $sssd_package   = 'sssd'
+      $sssd_service   = 'sssd'
+      $service_ensure = 'running'
+      $service_dependencies = []
+      $config_file    = '/etc/sssd/sssd.conf'
+      $mkhomedir      = true
+      $extra_packages = []
+      $extra_packages_ensure = 'present'
+      $manage_oddjobd        = false
+    }
+
     default: {
       fail("Unsupported osfamily: ${::osfamily}")
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -385,4 +385,61 @@ describe 'sssd' do
       it { is_expected.to contain_package('sssd').with_ensure('1.1.1') }
     end
   end
+  describe 'on Gentoo' do
+    let(:facts) do
+      {
+        :osfamily => 'Gentoo',
+        :operatingsystem => 'Gentoo',
+        :rubyversion => '1.9.3',
+      }
+    end
+
+    context 'with defaults for all parameters' do
+      it { is_expected.to contain_class('sssd::install') }
+      it { is_expected.to contain_class('sssd::config') }
+      it { is_expected.to contain_class('sssd::service') }
+
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(/^# Managed by Puppet.\n\n\[sssd\]/)
+      end
+
+      it { is_expected.not_to contain_package('authconfig') }
+      it { is_expected.not_to contain_package('oddjob-mkhomedir') }
+      it { is_expected.not_to contain_package('libpam-runtime').with_ensure('present') }
+      it { is_expected.not_to contain_service('oddjobd') }
+
+      it { is_expected.to contain_service('sssd').with_ensure('running') }
+      it { is_expected.to contain_package('sssd').with_ensure('present') }
+      it { is_expected.not_to contain_service('messagebus') }
+    end
+
+    context 'with service ensure stopped' do
+      let(:params) { { :service_ensure => 'stopped' } }
+      it { is_expected.to contain_service('sssd').with_ensure('stopped') }
+    end
+
+    context 'with ruby without ordered hashes' do
+      let(:facts) do
+        {
+          :osfamily => 'Gentoo',
+          :operatingsystem => 'Gentoo',
+          :rubyversion => '1.8.7'
+        }
+      end
+      it do
+        is_expected.to contain_file('sssd.conf') \
+          .with_ensure('present') \
+          .with_path('/etc/sssd/sssd.conf') \
+          .with_content(%r{^# Managed by Puppet.\n\n\[domain/ad.example.com\]})
+      end
+    end
+
+    context 'with package_ensure set to specific version' do
+      let(:params) { { :sssd_package_ensure => '1.1.1' } }
+      it { is_expected.to contain_package('sssd').with_ensure('1.1.1') }
+    end
+  end
 end


### PR DESCRIPTION
Adds basic support for Gentoo and derivatives. Tested on Sabayon Linux.

I've added basic tests (just a copy of the Debian tests), but I'm unable to run these to confirm if they work:

```
$ /opt/puppetlabs/puppet/bin/rake spec
An error occurred while loading ./spec/classes/init_spec.rb.
Failure/Error: require 'rspec-puppet-facts'

LoadError:
  cannot load such file -- rspec-puppet-facts
```
```
$ sudo  /opt/puppetlabs/puppet/bin/gem install rspec-puppet-facts
Fetching: facter-2.5.1.gem (100%)
facter's executable "facter" conflicts with /opt/puppetlabs/puppet/bin/facter
Overwrite the executable? [yN]  n
ERROR:  Error installing rspec-puppet-facts:
        "facter" from facter conflicts with /opt/puppetlabs/puppet/bin/facter
```