### PR TITLE
hiera.yaml: add yaml extension for file lookup

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,7 +6,7 @@ defaults:
 
 hierarchy:
   - name: "osfamily/major_release"
-    path: "os/%{facts.os.family}/%{facts.os.release.major}"
+    path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
 
   - name: "osfamily"
-    path: "osfamily/%{facts.os.family}"
+    path: "osfamily/%{facts.os.family}.yaml"

--- a/spec/hiera.yaml
+++ b/spec/hiera.yaml
@@ -4,5 +4,5 @@
 :yaml:
   :datadir: "data"
 :hierarchy:
-  - "os/%{facts.os.family}/%{facts.os.release.major}"
-  - "osfamily/%{facts.os.family}"
+  - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - "osfamily/%{facts.os.family}.yaml"


### PR DESCRIPTION
Before this commit hiera lookups for values within this module are
failing. This is because the file paths in the hiera.yaml file do not
specify the `.yaml` extension.

Snippet from `puppet lookup --debug --node <node> sssd::extra_packages`...

```
    Module "sssd" Data Provider (hiera configuration version 5)
      Using configuration "/etc/puppetlabs/code/environments/production/modules/sssd/hiera.yaml"
      Hierarchy entry "osfamily/major_release"
        Path "/etc/puppetlabs/code/environments/production/modules/sssd/data/os/RedHat/6"
          Original path: "os/%{facts.os.family}/%{facts.os.release.major}"
          Path not found
      Hierarchy entry "osfamily"
        Path "/etc/puppetlabs/code/environments/production/modules/sssd/data/osfamily/RedHat"
          Original path: "osfamily/%{facts.os.family}"
          Path not found
```

I only found this because the `$extra_packages` were not installing for me
after upgrading my module from 2.0.0 to 2.4.0.