### PR TITLE
support amazon linux 2

### DIFF
--- a/data/os/RedHat/2.yaml
+++ b/data/os/RedHat/2.yaml
@@ -1,0 +1,7 @@
+---
+
+sssd::extra_packages:
+  - 'authconfig'
+  - 'oddjob-mkhomedir'
+
+sssd::manage_oddjobd: true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -150,6 +150,25 @@ describe 'sssd' do
         },
       },
     },
+    'al2' => {
+      :extra_packages => [
+        'authconfig',
+        'oddjob-mkhomedir',
+      ],
+      :manage_oddjobd => true,
+      :facts_hash => {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Amazon',
+        :operatingsystemmajrelease => '2',
+        :os => {
+          'family' => 'RedHat',
+          'name'   => 'Amazon',
+          'release' => {
+            'major' => '2',
+          },
+        },
+      },
+    },
     'gentoo3' => {
       :manage_oddjobd => false,
       :facts_hash => {


### PR DESCRIPTION
This adds support for Amazon Linux 2.

Other than updating the checks for supported platforms I had to manually set the service provider to systemd for the oddjobd service when using Amazon Linux 2. Without this I'd receive these error messages during the puppet run:

`Error: Could not enable oddjobd: Execution of '/sbin/chkconfig --add oddjobd' returned 1: error reading information on service oddjobd: No such file or directory
Error: /Stage[main]/Sssd/Service[oddjobd]/ensure: change from 'stopped' to 'running' failed: Could not enable oddjobd: Execution of '/sbin/chkconfig --add oddjobd' returned 1: error reading information on service oddjobd: No such file or directory
`

Looks like there is an issue in puppet where it doesn't detect the provider as systemd for Amazon Linux 2 right now. See PUP-8248.
