### PR TITLE
Remove Absolutepath type for config_file option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,11 +85,11 @@ class sssd (
 ) {
 
   # Fail on unsupported platforms
-  if ($osfamily == 'RedHat') {
-    if ($osfamily== 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
+  if ($::facts['os']['family'] == 'RedHat') {
+    if ($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
       fail("osname Amazon's os.release.major is <${::facts['os']['release']['major']}> and must be 2.")
     }
-    if !($osfamily == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
+    if !($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
       fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora.")
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class sssd (
   String $sssd_service = 'sssd',
   Array $extra_packages = [],
   String $extra_packages_ensure = 'present',
-  Stdlib::Absolutepath $config_file = '/etc/sssd/sssd.conf',
+  String $config_file = '/etc/sssd/sssd.conf',
   String $config_template = 'sssd/sssd.conf.erb',
   Boolean $mkhomedir = true,
   Boolean $manage_oddjobd = false,
@@ -85,11 +85,11 @@ class sssd (
 ) {
 
   # Fail on unsupported platforms
-  if ($::facts['os']['family'] == 'RedHat') {
-    if ($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
+  if ($osfamily == 'RedHat') {
+    if ($osfamily== 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
       fail("osname Amazon's os.release.major is <${::facts['os']['release']['major']}> and must be 2.")
     }
-    if !($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
+    if !($osfamily == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
       fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora.")
     }
   }


### PR DESCRIPTION
Our version of `stdlib` is out-of-date and does not support `Absolutepath` types