### PR TITLE
Warn instead of fail on unsupported systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,27 +84,27 @@ class sssd (
   ],
 ) {
 
-  # Fail on unsupported platforms
+  # Warn on unsupported platforms
   if ($::facts['os']['family'] == 'RedHat') {
     if ($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
-      fail("osname Amazon's os.release.major is <${::facts['os']['release']['major']}> and must be 2.")
+      warning("osname Amazon's os.release.major is <${::facts['os']['release']['major']}> and must be 2.")
     }
     if !($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
-      fail("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora.")
+      warning("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora.")
     }
   }
 
   if $::facts['os']['family'] == 'Suse' {
     if !($::facts['os']['release']['major'] in ['11', '12']) {
-      fail("osfamily Suse's os.release.major is <${::facts['os']['release']['major']}> and must be 11 or 12.")
+      warning("osfamily Suse's os.release.major is <${::facts['os']['release']['major']}> and must be 11 or 12.")
     }
     if ($::facts['os']['release']['major'] == '11') and !($::facts['os']['release']['minor'] in ['3', '4']) {
-      fail("Suse 11's os.release.minor is <${::facts['os']['release']['minor']}> and must be 3 or 4.")
+      warning("Suse 11's os.release.minor is <${::facts['os']['release']['minor']}> and must be 3 or 4.")
     }
   }
 
   if ($::facts['os']['family'] == 'Debian') and !($::facts['os']['release']['major'] in ['7', '8', '9', '14.04', '16.04', '18.04']) {
-    fail("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 7, 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu.")
+    warning("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 7, 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu.")
   }
 
   # Manually set service provider to systemd on Amazon Linux 2

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -634,10 +634,10 @@ describe 'sssd' do
         }
       end
 
-      it 'unsupported Amazon Linux should fail' do
+      it 'unsupported Amazon Linux should still pass' do
         expect do
           should contain_class('sssd')
-        end.to raise_error(Puppet::Error, /osname Amazon's os\.release\.major is <1> and must be 2/)
+        end
       end
     end
 
@@ -656,10 +656,10 @@ describe 'sssd' do
         }
       end
 
-      it 'unsupported Debian / Ubuntu should fail' do
+      it 'unsupported Debian / Ubuntu should still pass' do
         expect do
           should contain_class('sssd')
-        end.to raise_error(Puppet::Error, /osfamily Debian's os\.release\.major is <6> and must be 7, 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu/)
+        end
       end
     end
 
@@ -678,10 +678,10 @@ describe 'sssd' do
         }
       end
 
-      it 'unsupported EL should fail' do
+      it 'unsupported EL should still pass' do
         expect do
           should contain_class('sssd')
-        end.to raise_error(Puppet::Error, /osfamily RedHat's os\.release\.major is <4> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora/)
+        end
       end
     end
 
@@ -701,10 +701,10 @@ describe 'sssd' do
         }
       end
 
-      it 'unsupported Suse should fail' do
+      it 'unsupported Suse should still pass' do
         expect do
           should contain_class('sssd')
-        end.to raise_error(Puppet::Error, /osfamily Suse's os\.release\.major is <10> and must be 11 or 12/)
+        end
       end
     end
 
@@ -725,10 +725,10 @@ describe 'sssd' do
         }
       end
 
-      it 'unsupported Suse 11 should fail' do
+      it 'unsupported Suse 11 should still pass' do
         expect do
           should contain_class('sssd')
-        end.to raise_error(Puppet::Error, /Suse 11's os\.release\.minor is <1> and must be 3 or 4/)
+        end
       end
     end
   end


### PR DESCRIPTION
This module works on some non-supported operating systems. While I understand all OS cannot be support, it would be nice to not have a hard failure. Instead, I've updated the code to warn. This would be very helpful for those aging or even new systems that aren't supported yet.