### PR TITLE
Require extra_packages be installed before starting oddjobd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,7 @@ class sssd (
         hasstatus  => true,
         hasrestart => true,
         provider   => $service_provider,
+        require    => Package[$extra_packages],
       }
     )
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -377,6 +377,13 @@ describe 'sssd' do
               :hasrestart => true,
             })
           end
+          if v[:extra_packages]
+            it do
+              should contain_service('oddjobd').that_requires(
+                v[:extra_packages].collect { |pkg| "Package[#{pkg}]" }
+              )
+            end
+          end
         else
           it { is_expected.not_to contain_service('oddjobd') }
         end


### PR DESCRIPTION
The oddjobd service will fail to start if the dependent packages aren't installed first:

```syslog
puppet-agent[48465]: (/Stage[main]/Sssd/Service[oddjobd]/ensure) change from 'stopped' to 'running' failed: Systemd start for oddjobd failed!
puppet-agent[48465]: (/Stage[main]/Sssd/Service[oddjobd]/ensure) journalctl log for oddjobd:
puppet-agent[48465]: (/Stage[main]/Sssd/Service[oddjobd]/ensure) -- No entries --
```

A second agent run solves this problem, but requiring the packages be installed before starting the service allows SSSD to be successfully configured in a single run.

This error was encountered on a CentOS7 node.