### PR TITLE
Remove "require" to avoid clash on $extra_packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,17 +122,17 @@ class sssd (
   ensure_packages($sssd_package,
     {
       ensure => $sssd_package_ensure,
-      before => File['sssd.conf'],
     }
   )
+  Package[$sssd_package] -> File['sssd.conf']
 
   if $extra_packages {
     ensure_packages($extra_packages,
       {
         ensure  => $extra_packages_ensure,
-        require => Package[$sssd_package],
       }
     )
+    Package[$sssd_package] -> Package[$extra_packages]
   }
 
   if ! empty($service_dependencies) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -396,8 +396,10 @@ describe 'sssd' do
         it do
           should contain_package('sssd').with({
             :ensure => 'present',
-            :before => 'File[sssd.conf]',
           })
+	end
+	it do
+	  should contain_package('sssd').that_comes_before('File[sssd.conf]')
         end
 
         if v[:extra_packages]
@@ -405,8 +407,10 @@ describe 'sssd' do
             it do
               should contain_package(pkg).with({
                 :ensure  => 'present',
-                :require => 'Package[sssd]',
               })
+            end
+            it do
+              should contain_package(pkg).that_requires('Package[sssd]')
             end
           end
         end
@@ -559,7 +563,7 @@ describe 'sssd' do
   describe 'with sssd_package set to valid string sssd-test' do
     let(:params) { { :sssd_package => 'sssd-test' } }
     it { should contain_package('sssd-test') }
-    it { should contain_package('authconfig').with_require('Package[sssd-test]') }
+    it { should contain_package('authconfig').that_requires('Package[sssd-test]') }
   end
 
   describe 'with sssd_package_ensure set to valid string absent' do


### PR DESCRIPTION
All classes using ensure_resources have to use the same parameters, so having explicit local dependencies results in a duplicate class definition error. Replace the "require" from the ensure_packages with a chained dependency.

I needed to make the changes to the ensure_packages for ssd as well to make the unit tests run, though I don't understand why this was necessary.

This fixes issue #81 