### PR TITLE
(GH-87) Drop support for end of life (EOL) platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,32 @@ Or you can use a relevant [module][1] for automation.
 
 ## Limitations
 
-Tested on:
+### Tested on
+
 * Amazon Linux 2
-* Debian 7,8,9
-* Fedora 26 and 27
-* (RHEL|CentOS|OracleLinux) 5,6,7
-* Gentoo 3 & 4
-* Ubuntu 14.04 & 16.04
-* Suse 11 & 12
+* Debian 8
+* Debian 9
+* EL 6
+* EL 7
+* Gentoo 4
+* Suse 11
+* Suse 12
+* Ubuntu 14.04
+* Ubuntu 16.04
+* Ubuntu 18.04
+
+### May work with
+
+These platforms are end of life (EOL) and once worked with the module
+and probably still do. We keep the data for them and if you use them a
+warning will appear instead of a failure. In order to speed up testing,
+we no longer run tests for EOL platforms.
+
+* Debian 7
+* EL 5
+* Fedora 26
+* Fedora 27
+* Gentoo 3
 
 ## Versioning
 The v1 series of this module will support both Puppet v3 and v4. The v2

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,8 +92,8 @@ class sssd (
     if ($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['2']) {
       warning("osname Amazon's os.release.major is <${::facts['os']['release']['major']}> and must be 2.")
     }
-    if !($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['5', '6', '7', '26', '27']) {
-      warning("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 5, 6 or 7 for EL and 26 or 27 for Fedora.")
+    if !($::facts['os']['name'] == 'Amazon') and !($::facts['os']['release']['major'] in ['6', '7']) {
+      warning("osfamily RedHat's os.release.major is <${::facts['os']['release']['major']}> and must be 6 or 7.")
     }
   }
 
@@ -106,8 +106,8 @@ class sssd (
     }
   }
 
-  if ($::facts['os']['family'] == 'Debian') and !($::facts['os']['release']['major'] in ['7', '8', '9', '14.04', '16.04', '18.04']) {
-    warning("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 7, 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu.")
+  if ($::facts['os']['family'] == 'Debian') and !($::facts['os']['release']['major'] in ['8', '9', '14.04', '16.04', '18.04']) {
+    warning("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu.")
   }
 
   # Manually set service provider to systemd on Amazon Linux 2

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,26 +20,6 @@ describe 'sssd' do
         },
       },
     },
-    'debian7' => {
-      :extra_packages => [
-        'libpam-runtime',
-        'libpam-sss',
-        'libnss-sss',
-      ],
-      :manage_oddjobd => false,
-      :facts_hash => {
-        :osfamily => 'Debian',
-        :operatingsystem => 'Debian',
-        :operatingsystemrelease => '7.1',
-        :operatingsystemmajrelease => '7',
-        :os => {
-          'family' => 'Debian',
-          'release' => {
-            'major' => '7',
-          },
-        },
-      },
-    },
     'debian8' => {
       :extra_packages => [
         'libpam-runtime',
@@ -80,22 +60,6 @@ describe 'sssd' do
         },
       },
     },
-    'el5' => {
-      :extra_packages => ['authconfig'],
-      :service_dependencies => ['messagebus'],
-      :manage_oddjobd => false,
-      :facts_hash => {
-        :osfamily => 'RedHat',
-        :operatingsystem => 'RedHat',
-        :operatingsystemmajrelease => '5',
-        :os => {
-          'family' => 'RedHat',
-          'release' => {
-            'major' => '5',
-          },
-        },
-      },
-    },
     'el6' => {
       :extra_packages => [
         'authconfig',
@@ -129,58 +93,6 @@ describe 'sssd' do
           'family' => 'RedHat',
           'release' => {
             'major' => '7',
-          },
-        },
-      },
-    },
-    'fedora26' => {
-      :extra_packages => [
-        'authconfig',
-        'oddjob-mkhomedir',
-      ],
-      :manage_oddjobd => true,
-      :facts_hash => {
-        :osfamily => 'RedHat',
-        :operatingsystem => 'RedHat',
-        :operatingsystemmajrelease => '26',
-        :os => {
-          'family' => 'RedHat',
-          'release' => {
-            'major' => '26',
-          },
-        },
-      },
-    },
-    'fedora27' => {
-      :extra_packages => [
-        'authconfig',
-        'oddjob-mkhomedir',
-      ],
-      :manage_oddjobd => true,
-      :facts_hash => {
-        :osfamily => 'RedHat',
-        :operatingsystem => 'RedHat',
-        :operatingsystemmajrelease => '27',
-        :os => {
-          'family' => 'RedHat',
-          'release' => {
-            'major' => '27',
-          },
-        },
-      },
-    },
-    'gentoo3' => {
-      :manage_oddjobd => false,
-      :facts_hash => {
-        :osfamily => 'Gentoo',
-        :operatingsystem => 'Gentoo',
-        :operatingsystemrelease => '3.14.36-gentoo',
-        :operatingsystemmajrelease => '3',
-        :os => {
-          'family' => 'Gentoo',
-          'release' => {
-            'major' => '3',
-            'minor' => '14',
           },
         },
       },
@@ -768,7 +680,7 @@ describe 'sssd' do
       end
     end
 
-    context 'Debian (not 7, 8 or 9 or Ubuntu 14.04, 16.04 or 18.04)' do
+    context 'Debian (not 8 or 9 or Ubuntu 14.04, 16.04 or 18.04)' do
       let(:facts) do
         {
           :osfamily => 'Debian',
@@ -790,7 +702,7 @@ describe 'sssd' do
       end
     end
 
-    context 'RedHat (not 5, 6 or 7 or Fedora 26 or 27)' do
+    context 'RedHat (not 6 or 7)' do
       let(:facts) do
         {
           :osfamily => 'RedHat',


### PR DESCRIPTION
This includes the following

* Debian 7
* EL 5
* Fedora 26
* Fedora 27
* Gentoo 3