### PR TITLE
Add support for Fedora versions 29 and 30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,30 @@ matrix:
   - rvm: 2.4.4
     sudo: required
     services: docker
+    env: BEAKER_set="fedora-29" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.3
+    sudo: required
+    services: docker
+    env: BEAKER_set="fedora-29" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
+    env: BEAKER_set="fedora-30" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.3
+    sudo: required
+    services: docker
+    env: BEAKER_set="fedora-30" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ currently Puppet versions 5 and 6.
 * Debian 9
 * EL 6
 * EL 7
+* Fedora 29
+* Fedora 30
 * Gentoo 4
 * Suse 11
 * Suse 12

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -147,8 +147,8 @@ Default value: []
 
 Data type: `Array`
 
-Array of flags to use with authconfig to enable
-auto-creation of home directories.
+Array of flags to use with authconfig
+or authselect to enable auto-creation of home directories.
 
 Default value: [
     '--enablesssd',
@@ -160,8 +160,8 @@ Default value: [
 
 Data type: `Array`
 
-Array of flags to use with authconfig to disable
-auto-creation of home directories.
+Array of flags to use with authconfig
+or authselect to disable auto-creation of home directories.
 
 Default value: [
     '--enablesssd',

--- a/data/os/RedHat/29.yaml
+++ b/data/os/RedHat/29.yaml
@@ -1,0 +1,11 @@
+---
+sssd::extra_packages:
+  - 'authselect'
+  - 'oddjob-mkhomedir'
+
+sssd::manage_oddjobd: true
+
+sssd::enable_mkhomedir_flags:
+  - 'with-mkhomedir'
+
+sssd::disable_mkhomedir_flags: []

--- a/data/os/RedHat/30.yaml
+++ b/data/os/RedHat/30.yaml
@@ -1,0 +1,11 @@
+---
+sssd::extra_packages:
+  - 'authselect'
+  - 'oddjob-mkhomedir'
+
+sssd::manage_oddjobd: true
+
+sssd::enable_mkhomedir_flags:
+  - 'with-mkhomedir'
+
+sssd::disable_mkhomedir_flags: []

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,10 @@
       "operatingsystemrelease": ["5","6","7"]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": ["29","30"]
+    },
+    {
       "operatingsystem": "Gentoo",
       "operatingsystemrelease": ["3","4"]
     },
@@ -29,7 +33,7 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": ["5","6","7"]
     },
-   {
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": ["14.04","16.04","18.04"]
     },

--- a/spec/acceptance/nodesets/fedora-29.yml
+++ b/spec/acceptance/nodesets/fedora-29.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  fedora29-64-1:
+    roles:
+      - agent
+    platform: fedora-29-x86_64
+    hypervisor: docker
+    image: fedora:29
+    docker_preserve_image: true
+    docker_cmd:
+      - "/sbin/init"
+    docker_image_commands:
+      - 'dnf install -y findutils wget'
+    docker_container_name: 'sssd-fc29'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/acceptance/nodesets/fedora-30.yml
+++ b/spec/acceptance/nodesets/fedora-30.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  fedora29-64-1:
+    roles:
+      - agent
+    platform: fedora-29-x86_64
+    hypervisor: docker
+    image: fedora:30
+    docker_preserve_image: true
+    docker_cmd:
+      - "/sbin/init"
+    docker_image_commands:
+      - 'dnf install -y findutils libxcrypt-compat wget'
+    docker_container_name: 'sssd-fc30'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -73,6 +73,7 @@ describe 'sssd' do
         :operatingsystemmajrelease => '6',
         :os => {
           'family' => 'RedHat',
+          'name'   => 'RedHat',
           'release' => {
             'major' => '6',
           },
@@ -91,8 +92,47 @@ describe 'sssd' do
         :operatingsystemmajrelease => '7',
         :os => {
           'family' => 'RedHat',
+          'name'   => 'RedHat',
           'release' => {
             'major' => '7',
+          },
+        },
+      },
+    },
+    'Fedora 29' => {
+      :extra_packages => [
+        'authselect',
+        'oddjob-mkhomedir',
+      ],
+      :manage_oddjobd => true,
+      :facts_hash => {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Fedora',
+        :operatingsystemmajrelease => '29',
+        :os => {
+          'family' => 'RedHat',
+          'name'   => 'Fedora',
+          'release' => {
+            'major' => '29',
+          },
+        },
+      },
+    },
+    'Fedora 30' => {
+      :extra_packages => [
+        'authselect',
+        'oddjob-mkhomedir',
+      ],
+      :manage_oddjobd => true,
+      :facts_hash => {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Fedora',
+        :operatingsystemmajrelease => '30',
+        :os => {
+          'family' => 'RedHat',
+          'name'   => 'Fedora',
+          'release' => {
+            'major' => '30',
           },
         },
       },
@@ -378,11 +418,21 @@ describe 'sssd' do
           })
         end
 
-        if v[:facts_hash][:osfamily] == 'RedHat'
+        if v[:facts_hash][:os]['name'] == 'RedHat'
           it do
             should contain_exec('authconfig-mkhomedir').with({
               :command => '/usr/sbin/authconfig --enablesssd --enablesssdauth --enablemkhomedir --update',
               :unless  => "/usr/bin/test \"`/usr/sbin/authconfig --enablesssd --enablesssdauth --enablemkhomedir --test`\" = \"`/usr/sbin/authconfig --test`\"",
+              :require => 'File[sssd.conf]',
+            })
+          end
+        end
+
+        if v[:facts_hash][:os]['name'] == 'Fedora'
+          it do
+            should contain_exec('authselect-mkhomedir').with({
+              :command => '/bin/authselect select sssd with-mkhomedir --force',
+              :unless  => "/usr/bin/test \"`/bin/authselect current --raw`\" = \"sssd with-mkhomedir\"",
               :require => 'File[sssd.conf]',
             })
           end
@@ -519,11 +569,20 @@ describe 'sssd' do
           v[:facts_hash]
         end
 
-        if v[:facts_hash][:osfamily] == 'RedHat'
+        if v[:facts_hash][:os]['name'] == 'RedHat'
           it do
             should contain_exec('authconfig-mkhomedir').with({
               :command => '/usr/sbin/authconfig --enablesssd --enablesssdauth --disablemkhomedir --update',
               :unless  => "/usr/bin/test \"`/usr/sbin/authconfig --enablesssd --enablesssdauth --disablemkhomedir --test`\" = \"`/usr/sbin/authconfig --test`\"",
+            })
+          end
+        end
+
+        if v[:facts_hash][:os]['name'] == 'Fedora'
+          it do
+            should contain_exec('authselect-mkhomedir').with({
+              :command => '/bin/authselect select sssd --force',
+              :unless  => "/usr/bin/test \"`/bin/authselect current --raw`\" = \"sssd\"",
             })
           end
         end


### PR DESCRIPTION
Add support for authselect enabled Fedora 29 and 30. Backwards
compatibility is maintained for Fedora 27 and older, which used
authconfig.

New unittests for Fedora 29 and 30 have been added. Conditional tests
previously based on the "osfamily" fact evaluating to RedHat have been
converted to use "os.name", which evaluates differently for RedHat and
Fedora operating systems.

Default values for (enable|disable)_mkhomedir_flags are now obfuscated
by the use of a params class. The default values have been added to
each parameter's YARD docstring.