### PR TITLE
Add missing dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -246,7 +246,7 @@ class sssd (
         exec { 'pam-auth-update':
           path        => '/bin:/usr/bin:/sbin:/usr/sbin',
           refreshonly => true,
-          require     => Package[$sssd_package], 
+          require     => Package[$sssd_package],
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -246,6 +246,7 @@ class sssd (
         exec { 'pam-auth-update':
           path        => '/bin:/usr/bin:/sbin:/usr/sbin',
           refreshonly => true,
+          require     => Package[$sssd_package], 
         }
       }
     }


### PR DESCRIPTION
This commit adds a missing dependency between the installation of the package and the `Exec[pam-auth-update]` resource.

Specifically, the `pam-auth-update` command consumes certain files, such as, `/usr/share/pam-configs/sss`, and `/usr/share/pam-configs/pwquality`, that are produced by the installation of the corresponding package.
Therefore, the parameter `require` should be added to the `exec` resource.