### PR TITLE
Add GitHub workflows for both specification and acceptance tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  spec:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { check: test, ruby_version: 2.4.10, puppet_gem_version: 5.0 }
+          - { check: test, ruby_version: 2.5.8, puppet_gem_version: 6.0 }
+          - { check: test, ruby_version: 2.7.2, puppet_gem_version: 7.0 }
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby_version}}
+    - name: Spec Tests
+      uses: puppetlabs/action-litmus_spec@master
+      env:
+        SPEC_OPTS: "--format documentation"
+      with:
+        puppet_gem_version: ${{matrix.puppet_gem_version}}
+        check: ${{matrix.check}}
+  accept:
+    needs: spec
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { beaker_set: centos-7, collection: puppet5 }
+          - { beaker_set: centos-7, collection: puppet6 }
+          - { beaker_set: centos-7, collection: puppet7 }
+          - { beaker_set: centos-8, collection: puppet5 }
+          - { beaker_set: centos-8, collection: puppet6 }
+          - { beaker_set: centos-8, collection: puppet7 }
+          - { beaker_set: debian-8, collection: puppet5 }
+          - { beaker_set: debian-9, collection: puppet6 }
+          - { beaker_set: fedora-30, collection: puppet6 }
+          - { beaker_set: fedora-30, collection: puppet7 }
+          - { beaker_set: fedora-31, collection: puppet6 }
+          - { beaker_set: fedora-31, collection: puppet7 }
+          - { beaker_set: fedora-32, collection: puppet6 }
+          - { beaker_set: fedora-32, collection: puppet7 }
+          - { beaker_set: fedora-33, collection: puppet6 }
+          - { beaker_set: fedora-33, collection: puppet7 }
+          - { beaker_set: ubuntu-1604, collection: puppet5 }
+          - { beaker_set: ubuntu-1604, collection: puppet6 }
+          - { beaker_set: ubuntu-1804, collection: puppet5 }
+          - { beaker_set: ubuntu-1804, collection: puppet6 }
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.2
+    - name: Acceptance Tests
+      env:
+        BEAKER_set: ${{matrix.beaker_set}}
+        BEAKER_PUPPET_COLLECTION: ${{matrix.collection}}
+      run: |
+        bundler install
+        bundler exec rake beaker

--- a/spec/acceptance/nodesets/fedora-30.yml
+++ b/spec/acceptance/nodesets/fedora-30.yml
@@ -2,7 +2,7 @@ HOSTS:
   fedora30-64-1:
     roles:
       - agent
-    platform: fedora-29-x86_64
+    platform: fedora-30-x86_64
     hypervisor: docker
     image: fedora:30
     docker_preserve_image: true


### PR DESCRIPTION
The following commit closely mirrors CI execution principles used in the project's Travis-CI environment. Puppet 7 specification support  and acceptance testing has been added. The following acceptance tests  pairs have been configured:
    
    centos-7 puppet5
    centos-7 puppet6
    centos-7 puppet7
    centos-8 puppet5
    centos-8 puppet6
    centos-8 puppet7
    debian-8 puppet5
    debian-9 puppet6
    fedora-30 puppet6
    fedora-30 puppet7
    fedora-31 puppet6
    fedora-31 puppet7
    fedora-32 puppet6
    fedora-32 puppet7
    fedora-33 puppet6
    fedora-33 puppet7
    ubuntu-1604 puppet5
    ubuntu-1604 puppet6
    ubuntu-1804 puppet5
    ubuntu-1804 puppet6
    
Three functionality omissions exist:

- The official CentOS 6 Docker Hub container has a YUM configuration error and thus has been omitted from this commit (todo).
- RHEL8 does not have an official Docker Hub container and will require further research.
- Automatic releasing of this module to Puppet Forge has not been implemented in the GitHub actions workflow.

A minor fix has been applied to the fedora-30 node-set specification, which should have been added in commit ID d418180.
