### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,8 +118,8 @@ class sssd (
     }
   }
 
-  if ($::facts['os']['family'] == 'Debian') and !($::facts['os']['release']['major'] in ['8', '9', '14.04', '16.04', '18.04']) {
-    warning("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 8 or 9 for Debian and 14.04, 16.04 or 18.04 for Ubuntu.")
+  if ($::facts['os']['family'] == 'Debian') and !($::facts['os']['release']['major'] in ['8', '9', '14.04', '16.04', '18.04', '20.04']) {
+    warning("osfamily Debian's os.release.major is <${::facts['os']['release']['major']}> and must be 8 or 9 for Debian and 14.04, 16.04, 18.04 or 20.04 for Ubuntu.")
   }
 
   # Manually set service provider to systemd on Amazon Linux 2
@@ -200,7 +200,7 @@ class sssd (
   case $::osfamily {
     'RedHat': {
       if ($::facts['os']['name'] == 'Fedora' and versioncmp($::facts['os']['release']['major'], '28') >= 0) or
-      ( $::facts['os']['family'] == 'RedHat' and versioncmp($::facts['os']['release']['major'], '8') >= 0) {
+      ( $::facts['os']['family'] == 'RedHat' and versioncmp($::facts['os']['release']['major'], '9') >= 0) {
         if $ensure == 'present' {
           $authselect_options = join(
             concat(


### PR DESCRIPTION
Used to fix with RHEL 8.5 and Ubuntu 20.04 LTS. 

If not added the condition to 9, will get error like these:

Info: Using configured environment 'predev'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for txxx-dev1.abc.x.y
Info: Applying configuration version 'txy-predev-ccbb56e1823'
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: Invalid option --enablesssd: unknown option
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: 
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: Usage: /bin/authselect select PROFILE-ID [OPTIONS...]
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: 
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: Command options:
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:   -f, --force           Enforce changes
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:   -b                    Backup system files before activating profile
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:                         (generate unique name)
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --backup=NAME     Backup system files before activating profile
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --nobackup        Do not backup system files when --force is set
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:   -q, --quiet           Do not print profile requirements
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: 
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: Common options:
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --debug           Print error messages
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --trace           Print trace messages
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --warn            Print warning messages
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: 
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: Help options:
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:   -?, --help            Show this help message
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns:       --usage           Display brief usage message
Notice: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: [error] Unable to parse command arguments
Error: '/bin/authselect select sssd --enablesssd --enablesssdauth --enablemkhomedir --force' returned 1 instead of one of [0]
Error: /Stage[main]/Sssd_test/Exec[authselect-mkhomedir]/returns: change from 'notrun' to ['0'] failed: '/bin/authselect select sssd --enablesssd --enablesssdauth --enablemkhomedir --force' returned 1 instead of one of [0]
Notice: Applied catalog in 4.79 seconds