### PR TITLE
fix osfamily fact and fix stdlib 9 warnings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@ class sssd (
     default   => true,
   }
 
-  ensure_packages($sssd_package,
+  stdlib::ensure_packages($sssd_package,
     {
       ensure => $sssd_package_ensure,
     }
@@ -144,7 +144,7 @@ class sssd (
   Package[$sssd_package] -> File['sssd.conf']
 
   if $extra_packages {
-    ensure_packages($extra_packages,
+    stdlib::ensure_packages($extra_packages,
       {
         ensure  => $extra_packages_ensure,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -197,7 +197,7 @@ class sssd (
     content => template($config_template),
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
       if ($::facts['os']['name'] == 'Fedora' and versioncmp($::facts['os']['release']['major'], '28') >= 0) or
       ( $::facts['os']['family'] == 'RedHat' and versioncmp($::facts['os']['release']['major'], '8') >= 0) {


### PR DESCRIPTION
`osfamily` fact is deprecated in puppet v8 so `os.family` is use instead (supported in lower puppet versions as well).

`ensure_packages` is deprecated in stdlib v9 and namespaced function `stdlib::ensure_packages` is used instead